### PR TITLE
Add Jetpack Compose MVVM sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
-# codex_test
+# TodoCompose
+
+A simple Android application built with Kotlin and Jetpack Compose using the MVVM architecture. The app displays a list of tasks.
+
+## Requirements
+
+- Android Studio Hedgehog (or newer)
+- Android SDK 34
+- Java 17+
+
+## Building and Running
+
+1. Clone this repository.
+2. Open the project in Android Studio.
+3. Let Gradle sync the project. Internet access is required on the first build to download dependencies.
+4. Connect an Android 12+ device or start an emulator.
+5. Click **Run** or execute:
+
+```bash
+./gradlew assembleDebug
+./gradlew installDebug
+```
+
+The app should install and launch on the connected device or emulator.
+
+## Project Structure
+
+- `app`: Android application module
+  - `ui`: Compose UI and ViewModel implementations
+  - `data`: Simple data classes
+
+The UI is implemented with Jetpack Compose. `TaskViewModel` exposes a `StateFlow` of tasks. `TaskListScreen` collects this flow and displays the items in a `LazyColumn`.
+
+## License
+
+This project is provided for demonstration purposes.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,0 +1,50 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.example.todo"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.example.todo"
+        minSdk = 31
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+        }
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+    buildFeatures {
+        compose = true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.6"
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("androidx.activity:activity-compose:1.9.0")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0")
+    implementation("androidx.navigation:navigation-compose:2.7.6")
+    implementation(platform("androidx.compose:compose-bom:2024.03.00"))
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.compose.material3:material3")
+
+    debugImplementation("androidx.compose.ui:ui-tooling")
+}

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Proguard rules for release build

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,15 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.todo">
+
+    <application
+        android:allowBackup="true"
+        android:label="@string/app_name"
+        android:theme="@style/Theme.Material3">
+        <activity android:name=".ui.MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/app/src/main/java/com/example/todo/data/Task.kt
+++ b/app/src/main/java/com/example/todo/data/Task.kt
@@ -1,0 +1,3 @@
+package com.example.todo.data
+
+data class Task(val id: Int, val title: String)

--- a/app/src/main/java/com/example/todo/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/todo/ui/MainActivity.kt
@@ -1,0 +1,21 @@
+package com.example.todo.ui
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import com.example.todo.ui.theme.Material3Theme
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            Material3Theme {
+                Surface(color = MaterialTheme.colorScheme.background) {
+                    TaskListScreen()
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/todo/ui/TaskListScreen.kt
+++ b/app/src/main/java/com/example/todo/ui/TaskListScreen.kt
@@ -1,0 +1,25 @@
+package com.example.todo.ui
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.compose.viewModel
+
+@Composable
+fun TaskListScreen(viewModel: TaskViewModel = viewModel()) {
+    val tasks = viewModel.tasks.collectAsState()
+
+    Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+        LazyColumn {
+            items(tasks.value) { task ->
+                Text(text = task.title, style = MaterialTheme.typography.bodyLarge)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/todo/ui/TaskViewModel.kt
+++ b/app/src/main/java/com/example/todo/ui/TaskViewModel.kt
@@ -1,0 +1,17 @@
+package com.example.todo.ui
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import com.example.todo.data.Task
+
+class TaskViewModel : ViewModel() {
+    private val _tasks = MutableStateFlow(
+        listOf(
+            Task(1, "Buy groceries"),
+            Task(2, "Walk the dog"),
+            Task(3, "Read a book")
+        )
+    )
+    val tasks: StateFlow<List<Task>> = _tasks
+}

--- a/app/src/main/java/com/example/todo/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/todo/ui/theme/Theme.kt
@@ -1,0 +1,19 @@
+package com.example.todo.ui.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+
+private val LightColors = lightColorScheme()
+private val DarkColors = darkColorScheme()
+
+@Composable
+fun Material3Theme(
+    darkTheme: Boolean = false,
+    content: @Composable () -> Unit
+) {
+    val colors = if (darkTheme) DarkColors else LightColors
+    MaterialTheme(colorScheme = colors, content = content)
+}

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,0 +1,5 @@
+<resources>
+    <color name="purple_200">#BB86FC</color>
+    <color name="purple_700">#3700B3</color>
+    <color name="teal_200">#03DAC5</color>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">TodoCompose</string>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,0 +1,5 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.Material3" parent="Theme.Material3.DayNight.NoActionBar">
+        <!-- Customize your theme here. -->
+    </style>
+</resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id("com.android.application") version "8.4.0" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.23" apply false
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,2 @@
+rootProject.name = "TodoCompose"
+include(":app")


### PR DESCRIPTION
## Summary
- create a minimal Android app module using Jetpack Compose
- implement `TaskViewModel` with `StateFlow`
- add simple Compose UI to display a list of tasks
- configure Gradle build files and Android manifest
- document how to build and run the sample

## Testing
- `gradle wrapper` *(fails: plugin not found in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_684a1779a4848325b0f290877cf14994