### PR TITLE
Fix Android plugin resolution

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,2 +1,9 @@
 rootProject.name = "TodoCompose"
 include(":app")
+
+pluginManagement {
+    repositories {
+        google()
+        gradlePluginPortal()
+    }
+}


### PR DESCRIPTION
## Summary
- add `pluginManagement` repositories so Gradle can resolve Android plugin

## Testing
- `gradle tasks`
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a292dddbc832588370de7682fad9f